### PR TITLE
sets timeout to 300 seconds.

### DIFF
--- a/cds/cds/sudocli.py
+++ b/cds/cds/sudocli.py
@@ -68,6 +68,11 @@ def cli(ctx):
         'nbgrader.preprocessors.OverwriteCells',
         'nbgrader.preprocessors.CheckCellMetadata'
     ]
+
+    # Increase default timeout to avoid timeout when grading exercises with slow
+    # cells. Adjust this number as needed.
+    config.ExecutePreprocessor.timeout = 300
+
     # Need to add both custom config here and in student_nbgrader_config.py
     config.ClearSolutions.code_stub = {
         "python": "### START ANSWER HERE ###\n### END ANSWER HERE ###"


### PR DESCRIPTION
There is a setting for when nbgrader will stop the execution of a cell. The default value is 30 seconds, and for some more demanding exercises, this can be to low. This PR increases the timeout to 300 seconds.